### PR TITLE
Add attribution on top of 3D view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MapTiler AR Control Changelog
 
+## 2.1.2
+### New Features
+- Display the attribution on top of the 3D model view (web)
+
+## 2.1.1
+### Others
+- updating license file for source-available publishing
+
 ## 2.1.0
 ### New Features
 - Now working also with Capacitor inside a mobile app (iOS only)
@@ -7,7 +15,6 @@
 - Optimization of the UMD bundle size
 ### Bug Fixes
 - Readme images are now stored on MapTiler CDN to be visible from NPM
-
 
 ## 2.0.1
 ### Bug Fixes

--- a/demos/index.html
+++ b/demos/index.html
@@ -97,6 +97,8 @@
         geolocate: true,
       });
 
+      console.log(map);
+
       // Waiting for the map to be ready
       map.on("load", (e) => {
         const arControl = new maptilerarcontrol.MaptilerARControl();

--- a/demos/index.html
+++ b/demos/index.html
@@ -97,8 +97,6 @@
         geolocate: true,
       });
 
-      console.log(map);
-
       // Waiting for the map to be ready
       map.on("load", (e) => {
         const arControl = new maptilerarcontrol.MaptilerARControl();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/ar-control",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "AR Control for MapTiler SDK",
   "type": "module",
   "homepage": "https://docs.maptiler.com/sdk-js/modules/ar/",

--- a/src/MaptilerARControl.ts
+++ b/src/MaptilerARControl.ts
@@ -1216,6 +1216,12 @@ export class MaptilerARControl extends EventEmitter implements IControl {
       this.close();
     });
 
+    // Adding the attribution
+    const attribDiv = this.createAttributionElement();
+    if (attribDiv) {
+      this.modelViewer.appendChild(attribDiv);
+    }
+
     // Adding a logo image
     if (this.logo) {
       this.logoImgElement = document.createElement("img");
@@ -1295,5 +1301,36 @@ export class MaptilerARControl extends EventEmitter implements IControl {
       this.logo = src;
       this.logoImgElement.src = src;
     }
+  }
+
+  private createAttributionElement(): HTMLDivElement | null {
+    // We are looking for an attribution control, and use its html content
+    const attribHTML = this.map._controls
+      .filter((c) => c._attribHTML)
+      .map((c) => c._attribHTML);
+    if (!attribHTML.length) return null;
+
+    const attribDiv = document.createElement("div") as HTMLDivElement;
+    attribDiv.innerHTML = attribHTML[0];
+    attribDiv.style.setProperty(
+      "font-family",
+      "12px / 20px Helvetica Neue, Arial, Helvetica, sans-serif"
+    );
+    attribDiv.style.setProperty("position", "absolute");
+    attribDiv.style.setProperty("bottom", 0);
+    attribDiv.style.setProperty("right", 0);
+    attribDiv.style.setProperty("width", "fit-content");
+    attribDiv.style.setProperty("height", "fit-content");
+    attribDiv.style.setProperty("padding", "1px 4px");
+    attribDiv.style.setProperty("font-size", "12px");
+    attribDiv.style.setProperty("background", "#FFFFFF80");
+
+    const links = attribDiv.getElementsByTagName("a");
+    for (const link of links) {
+      link.style.setProperty("color", "#000000");
+      link.style.setProperty("text-decoration", "none");
+    }
+
+    return attribDiv;
   }
 }


### PR DESCRIPTION
[RD-280](https://maptiler.atlassian.net/browse/RD-280)

Showing attribution on top of the web 3D model by reusnig the attribution from the Control:

<img width="1320" alt="Screenshot 2024-06-21 at 10 53 21" src="https://github.com/maptiler/maptiler-ar-control/assets/1303310/0e6b1944-0802-4d64-98e3-a1dd819e88b7">


[RD-280]: https://maptiler.atlassian.net/browse/RD-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ