### PR TITLE
fix/npm-versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MapTiler AR Control Changelog
 
+## v3.0.2
+- Fix declarations files generation
+
+## v3.0.0
+### Others
+- Using MapTiler SDK JS v3
+
 ## 2.1.3
 ### Others
 - Updating with SDK v2.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/ar-control",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/ar-control",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "See LICENSE.md",
       "dependencies": {
         "@capacitor-community/file-opener": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/ar-control",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "AR Control for MapTiler SDK",
   "type": "module",
   "homepage": "https://docs.maptiler.com/sdk-js/modules/ar/",


### PR DESCRIPTION
RD-398

## Objective
Release latest changed (SDK update and TS declarations fix).

## Description
During the `3.0.1-rc.1` release the version in `package.json` was incorrect (`3.0.1` instead of `3.0.1-rc1`).
Because of that, the `3.0.1` was published as "next" not "latest".
The result of it is that, the "3.0.1" already exists and we cannot update the tag.
According the NPM documentation this version cannot be updated nor re-published event if it was unpublished yesterday:
- https://docs.npmjs.com/policies/unpublish#considerations
- https://stackoverflow.com/a/60989025

## Acceptance
- _None_

## Checklist
- [x] I have added relevant info to the CHANGELOG.md