### PR TITLE
hotfix: update node version to lts/* for trusted publishing

### DIFF
--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-
+          node-version: lts/*
       - name: Install Node.js dependencies
         run: npm ci
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
           registry-url: https://registry.npmjs.org/
 
       - name: Clear NPM cache

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
           registry-url: https://registry.npmjs.org/
 
       - name: Clear NPM cache


### PR DESCRIPTION
Version bumps node version in our github actions to lts to ensure trusted publishing works.